### PR TITLE
path.join issue fix when the composerCommand is not defined

### DIFF
--- a/tasks/composer/init.js
+++ b/tasks/composer/init.js
@@ -21,7 +21,7 @@ module.exports = function (shipitInstance) {
     shipit.config.composer.installArgs = shipit.config.composer.installArgs || [];
     shipit.config.composer.installFlags = shipit.config.composer.installFlags || [];
 
-    shipit.config.composer.composerCommand = path.join(shipit.config.composer.composerCommand) !== undefined ? path.join(shipit.config.composer.composerCommand) : 'composer';
+    shipit.config.composer.composerCommand = shipit.config.composer.composerCommand !== undefined ? path.join(shipit.config.composer.composerCommand) : 'composer';
 
     var triggerEvent = shipit.config.composer.remote ? 'updated' : 'fetched';
     shipit.config.composer.triggerEvent = shipit.config.composer.triggerEvent !== undefined ? shipit.config.composer.triggerEvent : triggerEvent;


### PR DESCRIPTION
Fix for the #1 

Running 'composer:init' task...
'composer:init' errored after 2.61 ms
TypeError: Path must be a string. Received undefined
    at assertPath (path.js:8:11)
    at Object.posix.join (path.js:479:5)
    at Shipit.task (/var/www/wpflow/node_modules/shipit-composer/tasks/composer/init.js:24:51)
    at module.exports (/usr/local/lib/node_modules/shipit-cli/node_modules/orchestrator/lib/runTask.js:34:7)
    at Shipit.Orchestrator._runTask (/usr/local/lib/node_modules/shipit-cli/node_modules/orchestrator/index.js:273:3)
    at Shipit.Orchestrator._runStep (/usr/local/lib/node_modules/shipit-cli/node_modules/orchestrator/index.js:214:10)
    at /usr/local/lib/node_modules/shipit-cli/node_modules/orchestrator/index.js:279:18
    at finish (/usr/local/lib/node_modules/shipit-cli/node_modules/orchestrator/lib/runTask.js:21:8)
    at module.exports (/usr/local/lib/node_modules/shipit-cli/node_modules/orchestrator/lib/runTask.js:60:3)
    at Shipit.Orchestrator._runTask (/usr/local/lib/node_modules/shipit-cli/node_modules/orchestrator/index.js:273:3)
    at Shipit.Orchestrator._runStep (/usr/local/lib/node_modules/shipit-cli/node_modules/orchestrator/index.js:214:10)
    at Shipit.Orchestrator.start (/usr/local/lib/node_modules/shipit-cli/node_modules/orchestrator/index.js:134:8)
    at initShipit (/usr/local/lib/node_modules/shipit-cli/bin/shipit:81:10)
    at Liftoff.invoke (/usr/local/lib/node_modules/shipit-cli/bin/shipit:55:5)
    at Liftoff.<anonymous> (/usr/local/lib/node_modules/shipit-cli/node_modules/liftoff/index.js:192:16)
    at module.exports (/usr/local/lib/node_modules/shipit-cli/node_modules/liftoff/node_modules/flagged-respawn/index.js:17:3)
    at Liftoff.<anonymous> (/usr/local/lib/node_modules/shipit-cli/node_modules/liftoff/index.js:185:9)
    at /usr/local/lib/node_modules/shipit-cli/node_modules/liftoff/index.js:159:9
    at /usr/local/lib/node_modules/shipit-cli/node_modules/v8flags/index.js:99:14
    at /usr/local/lib/node_modules/shipit-cli/node_modules/v8flags/index.js:38:7
    at doNTCallback0 (node.js:419:9)
    at process._tickCallback (node.js:348:13)
